### PR TITLE
[PREVIEW] Document notes (very unfinished!!)

### DIFF
--- a/src/app/shared/components/document-viewer/annotations/note.ts
+++ b/src/app/shared/components/document-viewer/annotations/note.ts
@@ -1,0 +1,24 @@
+export const pageNoteType = 'PAGENOTE';
+
+export class Note {
+  url: string;
+  content: string;
+  page: number;
+
+  constructor(url = '', content: string = '', page: number = 1) {
+    this.url = url;
+    this.content = content;
+    this.page = page;
+  }
+
+  toObject() {
+    return {
+      page: this.page,
+      comments: [{
+        content: this.content
+      }],
+      type: pageNoteType
+    };
+  }
+}
+

--- a/src/app/shared/components/document-viewer/annotations/notes.service.ts
+++ b/src/app/shared/components/document-viewer/annotations/notes.service.ts
@@ -1,0 +1,108 @@
+import {Injectable} from '@angular/core';
+import {HttpClient, HttpHeaders} from '@angular/common/http';
+import {Observable} from 'rxjs/Observable';
+import {UrlFixerService} from '../url-fixer.service';
+import {Note, pageNoteType} from './note';
+
+@Injectable()
+export class NotesService {
+
+  private annotationSet: any;
+
+  constructor(private httpClient: HttpClient,
+              private urlFixer: UrlFixerService) {
+  }
+
+  getNotes(url): Promise<Note[]> {
+    return this.lookForAnnotationSets(url).then(possibleSet => {
+      if (possibleSet) {
+        this.annotationSet = possibleSet;
+        return this.extractNotes(possibleSet);
+      }
+      return this.initiateNewSet(url);
+    });
+  }
+
+  getNote(note: Note): Observable<Note> {
+    if (note.url) {
+      return this.httpClient.get(note.url, this.getHttpOptions()).map((n) => {
+        return this.newNoteFromAnnotation(n);
+      });
+    }
+    note.content = ''; // No URL means it's a new note so just clear the content.
+    return new Observable<Note>(observer => {
+      observer.next(note);
+    });
+  }
+
+  saveNote(note: Note): Observable<any> {
+    if (note.url) {
+      if (note.content) {
+        return this.httpClient.put(note.url, note.toObject(), this.getHttpOptions()).map(resp => note);
+      }
+      return this.httpClient.delete(note.url, this.getHttpOptions()).map(resp => {
+        note.url = '';
+        return note;
+      });
+    }
+    return this.httpClient.post(this.urlFixer.fixAnno(this.annotationSet._links['add-annotation'].href),
+                                note.toObject(),
+                                this.getHttpOptions())
+      .map(annotation => this.newNoteFromAnnotation(annotation));
+  }
+
+  private newNoteFromAnnotation(annotation) {
+    return new Note(this.urlFixer.fixAnno(annotation._links.self.href), annotation.comments[0].content, annotation.page);
+  }
+
+  private lookForAnnotationSets(url: string): Promise<any> {
+    return new Promise((resolve, reject) => {
+      const httpOptions = this.getHttpOptions();
+      const annoUrl = `/demproxy/an/annotation-sets/filter?url=${url}`;
+      this.httpClient.get<any>(annoUrl, httpOptions).subscribe(response => {
+        if (response._embedded && response._embedded.annotationSets && response._embedded.annotationSets.length) {
+          resolve(response._embedded.annotationSets[0]);
+        } else {
+          resolve(null);
+        }
+      }, reject);
+    });
+  }
+
+  private extractNotes(set) {
+    const notes = set.annotations
+      .filter(a => a.type === pageNoteType) // only page notes
+      .sort((a, b) => a.page - b.page) // order by page
+      .map(annotation => {
+        return this.newNoteFromAnnotation(annotation);
+      })
+      .reduce((acc, current) => {
+        acc[current.page - 1] = current;
+        return acc;
+      }, []);
+    return notes;
+  }
+
+  private initiateNewSet(url: string) {
+    return new Promise((resolve, reject) => {
+      const body = {
+        documentUri: url,
+        annotations: [],
+      };
+      this.httpClient.post('/demproxy/an/annotation-sets', body, this.getHttpOptions()).subscribe(response => {
+          this.annotationSet = response;
+          resolve(new Array<Note>());
+        },
+        reject);
+    });
+  }
+
+  private getHttpOptions() {
+    return {
+      headers: new HttpHeaders({
+        'Accept': 'application/json'
+      })
+    };
+  }
+
+}

--- a/src/app/shared/components/document-viewer/annotations/notes/notes.component.html
+++ b/src/app/shared/components/document-viewer/annotations/notes/notes.component.html
@@ -1,0 +1,18 @@
+<form id="notesForm" name="notesForm" #notesForm="ngForm">
+  <label class="form-label" for="currentNote">
+    Notes:
+    <span class="form-hint" *ngIf="numPages > 1">Page {{_page}}</span>
+  </label>
+
+  <textarea class="form-control" id="currentNote" name="currentNote" [(ngModel)]="currentNote.content"></textarea>
+
+  <div class="button-start">
+    <button class="button" [disabled]="!notesForm.form.dirty"
+            data-hook="dm.viewer.save-note"
+            (click)="save()">Save</button>
+
+    <button class="button button-warning" [disabled]="!notesForm.form.dirty"
+            data-hook="dm.viewer.cancel-note"
+            (click)="clear()">Cancel</button>
+  </div>
+</form>

--- a/src/app/shared/components/document-viewer/annotations/notes/notes.component.scss
+++ b/src/app/shared/components/document-viewer/annotations/notes/notes.component.scss
@@ -1,0 +1,4 @@
+textarea {
+  width : 100%;
+  height: 600px;
+}

--- a/src/app/shared/components/document-viewer/annotations/notes/notes.component.spec.ts
+++ b/src/app/shared/components/document-viewer/annotations/notes/notes.component.spec.ts
@@ -1,0 +1,317 @@
+import {async, ComponentFixture, TestBed} from '@angular/core/testing';
+import {FormsModule} from '@angular/forms';
+
+import {NotesComponent} from './notes.component';
+import {DebugElement} from '@angular/core';
+import {NotesService} from '../notes.service';
+import {HttpClientTestingModule, HttpTestingController} from '@angular/common/http/testing';
+
+import {UrlFixerService} from '../../../utils/url-fixer.service';
+import {Note} from '../note';
+
+const jwt = '12345';
+
+describe('NotesComponent', () => {
+  let component: NotesComponent;
+  let element: DebugElement;
+  let fixture: ComponentFixture<NotesComponent>;
+  let httpMock: HttpTestingController;
+  const val = '/demproxy/an/annotation-sets';
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [NotesComponent],
+      imports: [FormsModule, HttpClientTestingModule],
+      providers: [NotesService, UrlFixerService]
+    })
+      .compileComponents();
+  }));
+
+  beforeEach(async(() => {
+    fixture = TestBed.createComponent(NotesComponent);
+    httpMock = TestBed.get(HttpTestingController);
+    component = fixture.componentInstance;
+    element = fixture.debugElement;
+    component.url = 'https://doc123';
+    fixture.detectChanges();
+  }));
+
+  describe('when no notes are loaded', () => {
+    beforeEach(() => {
+      const req = httpMock.expectOne('/demproxy/an/annotation-sets/filter?url=https://doc123');
+      req.flush({
+        _embedded: {
+          annotationSets: []
+        }
+      });
+      component.page = 0;
+      fixture.detectChanges();
+    });
+
+    it('should create', () => {
+      expect(component).toBeTruthy();
+    });
+
+    it('should initialise to page 0', () => {
+      expect(component.page).toEqual(0);
+    });
+
+    it('should default to 0 pages', () => {
+      expect(component.numPages).toEqual(0);
+    });
+
+    describe('when there is a note against the current page', () => {
+      beforeEach(() => {
+        component.currentNote = new Note('', 'A note');
+        fixture.detectChanges();
+      });
+
+      describe('and we swap to the next page', () => {
+        beforeEach(() => {
+          component.page = 1;
+          fixture.detectChanges();
+        });
+
+        it('should update the current note to a blank note', () => {
+          expect(component.currentNote.content).toEqual('');
+        });
+
+        describe('when we swap back to the previous page', () => {
+          beforeEach(() => {
+            component.page = 0;
+            fixture.detectChanges();
+          });
+
+          it('should update the current note to the first page note', () => {
+            expect(component.currentNote.content).toEqual('A note');
+          });
+        });
+      });
+    });
+  });
+
+  describe('when notes are loaded', () => {
+    beforeEach(async(() => {
+      const req = httpMock.expectOne('/demproxy/an/annotation-sets/filter?url=https://doc123');
+      req.flush({
+        _embedded: {
+          annotationSets: [{
+            uuid: '1234',
+            annotations: [{
+              uuid: '1',
+              page: 2,
+              type: 'PAGENOTE',
+              comments: [{
+                content: 'Page 2 note'
+              }],
+              '_links': {
+                self: {
+                  href: 'http://test.com/annotation-sets/1234/annotation/1'
+                }
+              }
+            }, {
+              uuid: '2',
+              page: 1,
+              type: 'PAGENOTE',
+              comments: [{
+                content: 'Page 1 note'
+              }],
+              '_links': {
+                self: {
+                  href: 'http://test.com/annotation-sets/1234/annotation/2'
+                }
+              }
+            }, {
+              uuid: '3',
+              page: 1,
+              type: 'COMMENT',
+              comments: [{
+                content: 'Page 1 comment'
+              }],
+              '_links': {
+                self: {
+                  href: 'http://test.com/annotation-sets/1234/annotation/3'
+                }
+              }
+            }],
+            '_links': {
+              self: {
+                href: 'http://test.com/annotation-sets/1234'
+              },
+              'add-annotation': {
+                href: 'http://test.com/annotation-sets/1234/annotation'
+              }
+            }
+          }]
+        }
+      });
+      fixture.detectChanges();
+    }));
+
+    it('should filter out the non page note annotations', () => {
+      expect(component.notes.length).toBe(2);
+    });
+
+    it('should update the current note to the loaded note', () => {
+      expect(component.currentNote.content).toEqual('Page 1 note');
+    });
+
+    describe('when we change the current note and save', () => {
+      let putRequest;
+
+      beforeEach(async(() => {
+        component.currentNote.content = 'New page 1 note';
+        component.notesForm.form.markAsDirty();
+        fixture.detectChanges();
+        component.save();
+
+        putRequest = httpMock.expectOne('/demproxy/an/annotation-sets/1234/annotation/2');
+        putRequest.flush({}, {status: 200, statusText: 'Good!'});
+      }));
+
+      it('should be a put request', () => {
+        expect(putRequest.request.method).toEqual('PUT');
+      });
+
+      it('should set the form to pristine', () => {
+        expect(component.notesForm.form.dirty).toBe(false);
+      });
+    });
+
+    describe('when we change the current note and cancel', () => {
+      let putRequest;
+
+      beforeEach(async(() => {
+        component.currentNote.content = 'New page 1 note';
+        component.notesForm.form.markAsDirty();
+        fixture.detectChanges();
+        component.clear();
+
+        putRequest = httpMock.expectOne('/demproxy/an/annotation-sets/1234/annotation/2');
+        putRequest.flush({
+          uuid: '1',
+          page: 1,
+          type: 'PAGENOTE',
+          comments: [{
+            content: ''
+          }],
+          '_links': {
+            self: {
+              href: 'http://test.com/annotation-sets/1234/annotation/1'
+            }
+          }
+        });
+      }));
+
+      it('should be a get request', () => {
+        expect(putRequest.request.method).toEqual('GET');
+      });
+
+      it('should reset the content', () => {
+        expect(component.currentNote.content).toEqual('');
+      });
+    });
+  });
+
+  describe('when we remove the current note and save', () => {
+    let deleteRequest;
+
+    beforeEach(async(() => {
+      component.currentNote.content = '';
+      component.currentNote.url = '/demproxy/an/annotation-sets/1234/annotation/2';
+      component.notesForm.form.markAsDirty();
+      fixture.detectChanges();
+      component.save();
+
+      deleteRequest = httpMock.expectOne('/demproxy/an/annotation-sets/1234/annotation/2');
+      deleteRequest.flush({}, {status: 200, statusText: 'Good!'});
+    }));
+
+    it('should be a delete request', () => {
+      expect(deleteRequest.request.method).toEqual('DELETE');
+    });
+
+    it('should set the form to pristine', () => {
+      expect(component.notesForm.form.dirty).toBe(false);
+    });
+
+    it('should clear the url from the current note', () => {
+      expect(component.currentNote.url).toBe('');
+    });
+  });
+
+  describe('when we try and load notes but we have no sets', () => {
+    beforeEach(async(() => {
+      const req = httpMock.expectOne('/demproxy/an/annotation-sets/filter?url=https://doc123');
+      req.flush({});
+      fixture.detectChanges();
+    }));
+
+    beforeEach(async(() => {
+      const postReq = httpMock.expectOne('/demproxy/an/annotation-sets');
+      postReq.flush({
+        uuid: '1234',
+          annotations: [],
+          '_links': {
+          self: {
+            href: 'http://test.com/annotation-sets/1234'
+          },
+          'add-annotation': {
+            href: 'http://test.com/annotation-sets/1234/annotation'
+          }
+        }
+      });
+      fixture.detectChanges();
+    }));
+
+    it('should initialise blank note', () => {
+      expect(component.currentNote.content).toBe('');
+    });
+
+    describe('when I update the note and save', () => {
+      beforeEach(async(() => {
+        component.currentNote.content = 'A really great note';
+        fixture.detectChanges();
+        component.save();
+        const postReq = httpMock.expectOne('/demproxy/an/annotation-sets/1234/annotation');
+        postReq.flush({
+          uuid: '1',
+          page: 1,
+          type: 'PAGENOTE',
+          comments: [{
+            content: 'A really great note'
+          }],
+          '_links': {
+            self: {
+              href: 'http://test.com/annotation-sets/1234/annotation/1'
+            }
+          }
+        });
+      }));
+
+      it('should update the note with the generated url', () => {
+        expect(component.currentNote.url).toEqual('/demproxy/an/annotation-sets/1234/annotation/1');
+      });
+    });
+
+    describe('when I update the note and cancel', () => {
+      beforeEach(async(() => {
+        component.currentNote.content = 'A rubbish note';
+        fixture.detectChanges();
+        component.clear();
+        const postReq = httpMock.expectNone('/demproxy/an/annotation-sets/1234/annotation');
+      }));
+
+      it('should update the note with the generated url', () => {
+        expect(component.currentNote.content).toEqual('');
+      });
+    });
+  });
+
+  function newEvent(eventName: string, bubbles = false, cancelable = false) {
+    const evt = document.createEvent('CustomEvent');  // MUST be 'CustomEvent'
+    evt.initCustomEvent(eventName, bubbles, cancelable, null);
+    return evt;
+  }
+
+});

--- a/src/app/shared/components/document-viewer/annotations/notes/notes.component.ts
+++ b/src/app/shared/components/document-viewer/annotations/notes/notes.component.ts
@@ -1,0 +1,65 @@
+import {Component, Input, OnInit, ViewChild} from '@angular/core';
+import {NotesService} from '../notes.service';
+import {Note} from '../note';
+
+@Component({
+  selector: 'app-notes',
+  templateUrl: './notes.component.html',
+  styleUrls: ['./notes.component.scss']
+})
+export class NotesComponent implements OnInit {
+
+  @ViewChild('notesForm') notesForm;
+  private _page = 1;
+  @Input() numPages = 0;
+  @Input() url;
+
+  notes: Note[] = [];
+  private _currentNote: Note = new Note();
+
+  constructor(private notesService: NotesService) { }
+
+  ngOnInit() {
+    this.notesService.getNotes(this.url).then(notes => {
+      this.notes = notes;
+      this.page = this._page;
+    }).catch(console.log);
+  }
+
+  @Input() set page(value: number) {
+    this._page = value;
+    if (!this.notes[this._page - 1]) {
+      this.notes[this._page - 1] = new Note('', '', this._page);
+    }
+    this.currentNote = this.notes[this._page - 1];
+  }
+
+  get page(): number {
+    return this._page;
+  }
+
+  set currentNote(value: Note) {
+    this._currentNote = value;
+    this.notes[this._page - 1] = this._currentNote;
+  }
+
+  get currentNote(): Note {
+    return this._currentNote;
+  }
+
+  save() {
+    this.notesService.saveNote(this.currentNote).subscribe((note) => {
+      this._currentNote.url = note.url;
+      this.notesForm.form.markAsPristine();
+    }, error => {
+      console.log(error);
+    });
+  }
+
+  clear() {
+    this.notesService.getNote(this.currentNote).subscribe(note => {
+      this.currentNote = note;
+      this.notesForm.form.markAsPristine();
+    });
+  }
+}

--- a/src/app/shared/components/document-viewer/document-viewer.component.html
+++ b/src/app/shared/components/document-viewer/document-viewer.component.html
@@ -3,6 +3,12 @@
                  'column-two-thirds': annotate && viewerComponent && viewerComponent.numPages > 0}">
     <ng-template appViewerAnchor></ng-template>
   </div>
+    <app-notes *ngIf="annotate && viewerComponent && viewerComponent.numPages > 0"
+               class="column-one-third"
+               [url]="url"
+               [page]="viewerComponent.page"
+               [numPages]="viewerComponent.numPages">
+    </app-notes>
 </div>
 
 <div class="grid-row">

--- a/src/app/shared/components/document-viewer/document-viewer.module.ts
+++ b/src/app/shared/components/document-viewer/document-viewer.module.ts
@@ -11,6 +11,8 @@ import {ImgViewerComponent} from './viewers/img-viewer/img-viewer.component';
 import {ViewerAnchorDirective} from './viewers/viewer-anchor.directive';
 import {UrlFixerService} from './url-fixer.service';
 import {DocumentViewerService} from './document-viewer.service';
+import {NotesComponent} from './annotations/notes/notes.component';
+import {NotesService} from './annotations/notes.service';
 
 @NgModule({
     declarations: [
@@ -18,7 +20,8 @@ import {DocumentViewerService} from './document-viewer.service';
         PdfViewerComponent,
         ImgViewerComponent,
         UnsupportedViewerComponent,
-        ViewerAnchorDirective
+        ViewerAnchorDirective,
+        NotesComponent
     ],
     entryComponents: [
         PdfViewerComponent,
@@ -34,7 +37,8 @@ import {DocumentViewerService} from './document-viewer.service';
     providers: [
         ViewerFactoryService,
         UrlFixerService,
-        DocumentViewerService
+        DocumentViewerService,
+        NotesService
     ],
 })
 export class DocumentViewerModule {


### PR DESCRIPTION
Gavin asked me to look at putting the page notes feature from em viewer into JUI. I thought it'd be pretty easy but then remembered that JUI documents are displayed with all pages on screen at the same time whereas the old viewer had page navigation buttons. The notes component is designed to work by updating itself when you move from one page to the other. 

So fundamentally, whilst I think some code will be able to be reused (see the `em-viewer-web` repo), really we need a design from the designers for how this is going to go on the screen as that will massively impact the implementation.

So basically this is a pointless PR so feel free to delete it. It's just that there's not a Jira for this work (shocked face).