### PR TITLE
[PREVIEW] Refactor ui and api urls

### DIFF
--- a/api/cases/case/case.spec.js
+++ b/api/cases/case/case.spec.js
@@ -120,7 +120,7 @@ xdescribe('case spec', () => {
                 });
             };
         });
-        it('should return an error', () => request.get('/cases/jurisdiction/SSCS/casetype/Benefit/null')
+        it('should return an error', () => request.get('/case/SSCS/Benefit/null')
             .expect(400));
     });
 
@@ -161,7 +161,7 @@ xdescribe('case spec', () => {
             questionsGetHttpResponse = resolve => resolve();
         });
 
-        it('should populate the summary panel given data is in the response', () => request.get('/jurisdiction/SSCS/casetype/Benefit/1').expect(200)
+        it('should populate the summary panel given data is in the response', () => request.get('/SSCS/Benefit/1').expect(200)
             .then(response => {
                 const jsonRes = JSON.parse(response.text);
                 const actualSummarySection = jsonRes.sections.filter(section => section.id === 'summary')[0];

--- a/api/cases/case/index.js
+++ b/api/cases/case/index.js
@@ -75,9 +75,9 @@ function getOptionsDoc(req) {
 // GET case callback
 module.exports = app => {
     const router = express.Router({ mergeParams: true })
-    app.use('/cases', router)
+    app.use('/case', router)
 
-    router.get('/jurisdiction/:jur/casetype/:casetype/:case_id', (req, res, next) => {
+    router.get('/:jur/:casetype/:case_id', (req, res, next) => {
         const userId = req.auth.userId
         const jurisdiction = req.params.jur
         const caseType = req.params.casetype
@@ -131,7 +131,7 @@ module.exports = app => {
             });
     });
 
-    router.get('/jurisdiction/:jur/casetype/:casetype/:case_id/raw', (req, res, next) => {
+    router.get('/:jur/:casetype/:case_id/raw', (req, res, next) => {
         const userId = req.auth.userId;
         const jurisdiction = req.params.jur;
         const caseType = req.params.casetype;

--- a/api/events/event.js
+++ b/api/events/event.js
@@ -34,14 +34,12 @@ function reduceCcdEvents(events, caseId, jurisdiction, caseType) {
         const date = dateObj.date;
         const time = dateObj.time;
 
-
-
         valueProcessor(getEventTemplate(jurisdiction, caseType), event);
 
         const documents = event.documents.map(doc => {
             return ({
                 name: `${doc.document_filename}`,
-                href: `/jurisdiction/${jurisdiction}/casetype/${caseType}/viewcase/${caseId}/casefile/${doc.id}`
+                href: `/case/${jurisdiction}/${caseType}/${caseId}/casefile/${doc.id}`
             });
         });
 
@@ -138,9 +136,9 @@ function getOptions(req) {
 
 module.exports = app => {
     const router = express.Router({ mergeParams: true });
-    app.use('/cases', router);
+    app.use('/case', router);
 
-    router.get('/jurisdiction/:jur/casetype/:casetype/:case_id/events', (req, res, next) => {
+    router.get('/:jur/:casetype/:case_id/events', (req, res, next) => {
         const userId = req.auth.userId;
         const caseId = req.params.case_id;
         const jurisdiction = req.params.jur;
@@ -154,7 +152,7 @@ module.exports = app => {
             });
     });
 
-    router.get('/jurisdiction/:jur/casetype/:casetype/:case_id/events/raw', (req, res, next) => {
+    router.get('/:jur/:casetype/:case_id/events/raw', (req, res, next) => {
         const userId = req.auth.userId;
         const caseId = req.params.case_id;
         const jurisdiction = req.params.jur;

--- a/api/hearings/hearing.js
+++ b/api/hearings/hearing.js
@@ -16,7 +16,7 @@ module.exports = app => {
     const casesRouter = express.Router({ mergeParams: true });
     app.use('/cases', casesRouter);
 
-    casesRouter.get('/jurisdiction/:jur/casetype/:casetype/:case_id/hearing', (req, res, next) => {
+    casesRouter.get('/:jur/:casetype/:case_id/hearing', (req, res, next) => {
         const userId = req.auth.userId;
         const caseId = req.params.case_id;
         const options = getOptions(req);

--- a/api/questions/question.js
+++ b/api/questions/question.js
@@ -153,7 +153,7 @@ function getOptions(req) {
 
 module.exports = app => {
     const route = express.Router({ mergeParams: true });
-    app.use('/cases', route);
+    app.use('/case', route);
 
     // GET A Question
     route.get('/:case_id/questions/:question_id', (req, res, next) => {

--- a/api/questions/question.spec.js
+++ b/api/questions/question.spec.js
@@ -62,7 +62,7 @@ xdescribe('Questions route', () => {
 
         describe('When I do not have an answer', () => {
             it('It should return the question', done => {
-                request.get(`/cases/${caseNumber}/questions/${questionId}`)
+                request.get(`/case/${caseNumber}/questions/${questionId}`)
                     .expect(200)
                     .then(response => {
                         expect(response.body).toEqual({
@@ -90,7 +90,7 @@ xdescribe('Questions route', () => {
 
 
             it('It should return the question with the answer', done => {
-                request.get(`/cases/${caseNumber}/questions/${questionId}`)
+                request.get(`/case/${caseNumber}/questions/${questionId}`)
                     .expect(200)
                     .then(response => {
                         expect(response.body).toEqual({
@@ -151,7 +151,7 @@ xdescribe('Questions route', () => {
             });
 
             it('should return a list of formatted questions', done => {
-                request.get(`/cases/${caseNumber}/questions`)
+                request.get(`/case/${caseNumber}/questions`)
                     .expect(200)
                     .then(response => {
                         expect(response.body).toEqual([
@@ -190,7 +190,7 @@ xdescribe('Questions route', () => {
             });
 
             it('should return a an empty list', done => {
-                request.get(`/cases/${caseNumber}/questions`)
+                request.get(`/case/${caseNumber}/questions`)
                     .expect(200)
                     .then(response => {
                         expect(response.body).toEqual([]);
@@ -222,7 +222,7 @@ xdescribe('Questions route', () => {
             });
 
             it('It should make a post request', done => {
-                request.post(`/cases/${caseNumber}/questions`)
+                request.post(`/case/${caseNumber}/questions`)
                     .expect(201)
                     .send({
                         subject: 'A great question',

--- a/src/app/domain/components/casebar/casebar.component.spec.ts
+++ b/src/app/domain/components/casebar/casebar.component.spec.ts
@@ -9,7 +9,7 @@ import { BrowserTransferStateModule } from '@angular/platform-browser';
 import { RouterTestingModule } from '@angular/router/testing';
 import {Selector} from '../../../../../test/selector-helper';
 
-const caseUrl = '/api/cases/1531309876267122';
+const caseUrl = '/api/case/1531309876267122';
 const configMock = {
     config: {
         api_base_url: ''

--- a/src/app/domain/components/questions/check/check.component.spec.ts
+++ b/src/app/domain/components/questions/check/check.component.spec.ts
@@ -132,7 +132,7 @@ fdescribe('CheckQuestionsComponent', () => {
                 },
                 'deadline_extension_count': 0
             };
-            request = httpMock.expectOne('/api/cases/123456789/rounds/1');
+            request = httpMock.expectOne('/api/case/123456789/rounds/1');
             request.flush(mockData);
             fixture.detectChanges();
         }));
@@ -152,23 +152,23 @@ fdescribe('CheckQuestionsComponent', () => {
 
             // describe('and it succeeds', () => {
             //     beforeEach(() => {
-            //         const req = httpMock.expectOne('/api/cases/123456789/rounds/1');
+            //         const req = httpMock.expectOne('/api/case/123456789/rounds/1');
             //         req.flush({});
             //     });
             //
             //     it('should redirect with success', () => {
-            //         expect(redirectionService.redirect).toHaveBeenCalledWith('/jurisdiction/SSCS/casetype/Benefit/viewcase/123456789/questions?sent=success');
+            //         expect(redirectionService.redirect).toHaveBeenCalledWith('/SSCS/Benefit/123456789/questions?sent=success');
             //     });
             // });
 
             // describe('and it fails', () => {
             //     beforeEach(() => {
-            //         const req = httpMock.expectOne('/api/cases/123456789/rounds/1');
+            //         const req = httpMock.expectOne('/api/case/123456789/rounds/1');
             //         req.flush({}, {status: 500, statusText: 'It broke'});
             //     });
             //
             //     it('should redirect with failure', () => {
-            //         expect(redirectionService.redirect).toHaveBeenCalledWith('/jurisdiction/SSCS/casetype/Benefit/viewcase/123456789/questions?sent=failure');
+            //         expect(redirectionService.redirect).toHaveBeenCalledWith('/SSCS/Benefit/123456789/questions?sent=failure');
             //     });
             // });
 

--- a/src/app/domain/components/questions/check/check.component.ts
+++ b/src/app/domain/components/questions/check/check.component.ts
@@ -43,9 +43,9 @@ export class CheckQuestionsComponent implements OnInit {
 
     onSubmit() {
         this.questionService.sendQuestions(this.caseId, this.roundNumber).subscribe(res => {
-            this.redirectionService.redirect(`/jurisdiction/${this.jurisdiction}/casetype/${this.caseType}/viewcase/${this.caseId}/questions?sent=success`);
+            this.redirectionService.redirect(`/case/${this.jurisdiction}/${this.caseType}/${this.caseId}/questions?sent=success`);
         }, () => {
-            this.redirectionService.redirect(`/jurisdiction/${this.jurisdiction}/casetype/${this.caseType}/viewcase/${this.caseId}/questions?sent=failure`);
+            this.redirectionService.redirect(`/case/${this.jurisdiction}/${this.caseType}/${this.caseId}/questions?sent=failure`);
         });
     }
 }

--- a/src/app/domain/components/questions/create/create.component.spec.ts
+++ b/src/app/domain/components/questions/create/create.component.spec.ts
@@ -155,7 +155,7 @@ describe('CreateQuestionsComponent', () => {
 
             component.submitCallback({});
             httpMock
-                .expectOne('/api/cases/13eb9981-9360-4d4b-b9fd-506b5818e7ff/questions')
+                .expectOne('/api/case/13eb9981-9360-4d4b-b9fd-506b5818e7ff/questions')
                 .flush({question_id: '9727a0fc-11bb-4212-821f-b36e312bbace'});
         });
 

--- a/src/app/domain/components/questions/create/create.component.ts
+++ b/src/app/domain/components/questions/create/create.component.ts
@@ -68,7 +68,7 @@ export class CreateQuestionsComponent implements OnInit {
         if (this.form.valid) {
             this.questionService.create(this.caseId, values)
                 .subscribe(res => {
-                    this.redirectionService.redirect(`/jurisdiction/${this.jurisdiction}/casetype/${this.caseType}/viewcase/${this.caseId}/questions?created=success`);
+                    this.redirectionService.redirect(`/case/${this.jurisdiction}/${this.caseType}/${this.caseId}/questions?created=success`);
                 }, err => console.log);
         }
         else {

--- a/src/app/domain/components/questions/delete/delete.component.spec.ts
+++ b/src/app/domain/components/questions/delete/delete.component.spec.ts
@@ -96,7 +96,7 @@ describe('DeleteQuestionComponent', () => {
             component.remove();
 
             httpMock
-                .expectOne('/api/cases/99eb9981-9360-4d4b-b9fd-506b5818e7ff/questions/13eb9981-9360-4d4b-b9fd-506b5818e7ff')
+                .expectOne('/api/case/99eb9981-9360-4d4b-b9fd-506b5818e7ff/questions/13eb9981-9360-4d4b-b9fd-506b5818e7ff')
                 .flush(null);
 
             expect(redirectionServiceMock).toHaveBeenCalled();

--- a/src/app/domain/components/questions/delete/delete.component.ts
+++ b/src/app/domain/components/questions/delete/delete.component.ts
@@ -30,7 +30,7 @@ export class DeleteQuestionComponent implements OnInit {
 
     remove() {
         this.questionService.remove(this.caseId, this.questionId).subscribe(res => {
-            this.redirectionService.redirect(`/jurisdiction/${this.jurisdiction}/casetype/${this.caseType}/viewcase/${this.caseId}/questions?deleted=success`);
+            this.redirectionService.redirect(`/case/${this.jurisdiction}/${this.caseType}/${this.caseId}/questions?deleted=success`);
         }, err => console.log);
     }
 }

--- a/src/app/domain/components/questions/edit/edit.component.spec.ts
+++ b/src/app/domain/components/questions/edit/edit.component.spec.ts
@@ -94,7 +94,7 @@ describe('EditQuestionComponent', () => {
     describe('When request is a success', () => {
         beforeEach(async(() => {
             httpMock
-                .expectOne('/api/cases/13eb9981-9360-4d4b-b9fd-506b5818e7ff/questions/43eb9981-9360-4d4b-b9fd-506b5818e7ff')
+                .expectOne('/api/case/13eb9981-9360-4d4b-b9fd-506b5818e7ff/questions/43eb9981-9360-4d4b-b9fd-506b5818e7ff')
                 .flush({header: 'Example header', body: 'Example body'});
 
             fixture.whenStable()

--- a/src/app/domain/components/questions/edit/edit.component.ts
+++ b/src/app/domain/components/questions/edit/edit.component.ts
@@ -70,7 +70,7 @@ export class EditQuestionComponent implements OnInit {
             };
             this.questionService.update(this.caseId, this.questionId, values)
                 .subscribe(res => {
-                    this.redirectionService.redirect(`/jurisdiction/${this.jurisdiction}/casetype/${this.caseType}/viewcase/${this.caseId}/questions?updated=success`);
+                    this.redirectionService.redirect(`/case/${this.jurisdiction}/${this.caseType}/${this.caseId}/questions?updated=success`);
                 }, err => console.log(err));
         }
         this.submitted = true;

--- a/src/app/domain/components/questions/view/view.component.spec.ts
+++ b/src/app/domain/components/questions/view/view.component.spec.ts
@@ -94,7 +94,7 @@ describe('ViewQuestionComponent', () => {
     describe('when we receive a question and no answer', () => {
         beforeEach(async(() => {
             httpMock
-                .expectOne('/api/cases/13eb9981-9360-4d4b-b9fd-506b5818e7ff/questions/43eb9981-9360-4d4b-b9fd-506b5818e7ff')
+                .expectOne('/api/case/13eb9981-9360-4d4b-b9fd-506b5818e7ff/questions/43eb9981-9360-4d4b-b9fd-506b5818e7ff')
                 .flush({
                     'id': '43eb9981-9360-4d4b-b9fd-506b5818e7ff',
                     'header': 'Locality',
@@ -128,7 +128,7 @@ describe('ViewQuestionComponent', () => {
     describe('when we receive a question and an answer', () => {
         beforeEach(async(() => {
             httpMock
-                .expectOne('/api/cases/13eb9981-9360-4d4b-b9fd-506b5818e7ff/questions/43eb9981-9360-4d4b-b9fd-506b5818e7ff')
+                .expectOne('/api/case/13eb9981-9360-4d4b-b9fd-506b5818e7ff/questions/43eb9981-9360-4d4b-b9fd-506b5818e7ff')
                 .flush({
                     'id': '43eb9981-9360-4d4b-b9fd-506b5818e7ff',
                     'header': 'Locality',

--- a/src/app/domain/services/case.service.spec.ts
+++ b/src/app/domain/services/case.service.spec.ts
@@ -48,7 +48,7 @@ describe('CaseService', () => {
         const mockJudistdiction = 'DIVORCE';
         const mockCaseId = '123';
         const mockCaseType = 'DIVORCE';
-        const url = `/api/cases/jurisdiction/${mockJudistdiction}/casetype/${mockCaseType}/${mockCaseId}`;
+        const url = `/api/case/${mockJudistdiction}/${mockCaseType}/${mockCaseId}`;
         caseService.fetch(mockCaseId, mockJudistdiction, mockCaseType).subscribe(data => {
              expect(data).toEqual(mockCaseData);
         });

--- a/src/app/domain/services/case.service.ts
+++ b/src/app/domain/services/case.service.ts
@@ -15,7 +15,7 @@ export class CaseService {
     }
 
     fetch(caseId, jurisdiction, casetype): Observable<Object> {
-        const url = `${this.configService.config.api_base_url}/api/cases/jurisdiction/${jurisdiction}/casetype/${casetype}/${caseId}`;
+        const url = `${this.configService.config.api_base_url}/api/case/${jurisdiction}/${casetype}/${caseId}`;
         const key = makeStateKey(url);
         const cache = this.state.get(key, null as any);
         if (cache) {

--- a/src/app/domain/services/question.service.ts
+++ b/src/app/domain/services/question.service.ts
@@ -12,12 +12,12 @@ export class QuestionService {
     }
 
     fetch(caseId, questionId): Observable<Object> {
-        const url = `${this.configService.config.api_base_url}/api/cases/${caseId}/questions/${questionId}`;
+        const url = `${this.configService.config.api_base_url}/api/case/${caseId}/questions/${questionId}`;
         return this.fetchWithUrl(url);
     }
 
     fetchAll(caseId): Observable<any[]> {
-        const url = `${this.configService.config.api_base_url}/api/cases/${caseId}/questions`;
+        const url = `${this.configService.config.api_base_url}/api/case/${caseId}/questions`;
         return this.fetchWithUrl(url);
     }
 
@@ -36,24 +36,24 @@ export class QuestionService {
 
     create(caseId, question) {
         return this.http
-                   .post(`${this.configService.config.api_base_url}/api/cases/${caseId}/questions`, question);
+                   .post(`${this.configService.config.api_base_url}/api/case/${caseId}/questions`, question);
     }
 
     update(caseId, questionId, question) {
         return this.http
-                   .put(`${this.configService.config.api_base_url}/api/cases/${caseId}/questions/${questionId}`, question);
+                   .put(`${this.configService.config.api_base_url}/api/case/${caseId}/questions/${questionId}`, question);
     }
 
     remove(caseId, questionId) {
         return this.http
-                   .delete(`${this.configService.config.api_base_url}/api/cases/${caseId}/questions/${questionId}`);
+                   .delete(`${this.configService.config.api_base_url}/api/case/${caseId}/questions/${questionId}`);
     }
 
     sendQuestions(caseId, roundId) {
-        return this.http.put(`${this.configService.config.api_base_url}/api/cases/${caseId}/rounds/${roundId}`, {});
+        return this.http.put(`${this.configService.config.api_base_url}/api/case/${caseId}/rounds/${roundId}`, {});
     }
 
     fetchRound(caseId, roundId): any {
-        return this.http.get(`${this.configService.config.api_base_url}/api/cases/${caseId}/rounds/${roundId}`);
+        return this.http.get(`${this.configService.config.api_base_url}/api/case/${caseId}/rounds/${roundId}`);
     }
 }

--- a/src/app/routing/pages/decisions/create-decision/create-decision.component.ts
+++ b/src/app/routing/pages/decisions/create-decision/create-decision.component.ts
@@ -70,14 +70,14 @@ export class CreateDecisionComponent implements OnInit {
             if(this.decision) {
                 this.decisionService.updateDecisionDraft(this.case.id, values.decision, values.notes)
                     .subscribe(
-                        () => this.redirectionService.redirect(`/jurisdiction/${this.case.case_jurisdiction}/casetype/${this.case.case_type_id}/viewcase/${this.case.id}/decision/check`),
+                        () => this.redirectionService.redirect(`/case/${this.case.case_jurisdiction}/${this.case.case_type_id}/${this.case.id}/decision/check`),
                         error => this.error.server = true
                     );
             }
             else {
                 this.decisionService.submitDecisionDraft(this.case.id, values.decision, values.notes, null)
                     .subscribe(
-                        () => this.redirectionService.redirect(`/jurisdiction/${this.case.case_jurisdiction}/casetype/${this.case.case_type_id}/viewcase/${this.case.id}/decision/check`),
+                        () => this.redirectionService.redirect(`/case/${this.case.case_jurisdiction}/${this.case.case_type_id}/${this.case.id}/decision/check`),
                         error => this.error.server = true
                     );
             }

--- a/src/app/routing/pages/hearings/check-hearing/check-hearing.component.ts
+++ b/src/app/routing/pages/hearings/check-hearing/check-hearing.component.ts
@@ -49,7 +49,7 @@ export class CheckHearingComponent implements OnInit {
         if (this.form.valid) {
             this.hearingService.listForHearing(this.case.id, this.relistReasonText)
                 .subscribe(() => {
-                        this.redirectionService.redirect(`/jurisdiction/${this.case.case_jurisdiction}/casetype/${this.case.case_type_id}/viewcase/${this.case.id}/hearing/confirm`);
+                        this.redirectionService.redirect(`/case/${this.case.case_jurisdiction}/${this.case.case_type_id}/${this.case.id}/hearing/confirm`);
                     }, error => {
                         this.error = true;
                         console.error('Something went wrong', error);

--- a/src/app/routing/pages/view-case/view-case.component.spec.ts
+++ b/src/app/routing/pages/view-case/view-case.component.spec.ts
@@ -88,7 +88,7 @@ describe('ViewCaseComponent', () => {
             expect(linkElements.length).toEqual(3);
             const linkEl = linkElements[0];
             expect(linkEl.tagName).toEqual('A');
-            expect(linkEl.getAttribute('href')).toEqual('/jurisdiction/SSCS/casetype/Benefit/viewcase/case_id/section_id1');
+            expect(linkEl.getAttribute('href')).toEqual('/case/SSCS/Benefit/case_id/section_id1');
             expect(linkEl.innerHTML).toEqual('section_name1');
         });
     });

--- a/src/app/routing/pages/view-case/view-case.component.ts
+++ b/src/app/routing/pages/view-case/view-case.component.ts
@@ -29,7 +29,7 @@ export class ViewCaseComponent implements OnInit {
         if (this.case) {
             this.links = this.case.sections.map(section => {
                 return {
-                    href: `/jurisdiction/${this.case.case_jurisdiction}/casetype/${this.case.case_type_id}/viewcase/${this.case.id}/${section.id}`,
+                    href: `/case/${this.case.case_jurisdiction}/${this.case.case_type_id}/${this.case.id}/${section.id}`,
                     text: section.name,
                     label: section.name,
                     id: section.id,

--- a/src/app/routing/routing.module.ts
+++ b/src/app/routing/routing.module.ts
@@ -72,7 +72,7 @@ const routes: Routes = [
         ]
     },
     {
-        path: 'jurisdiction/:jur/casetype/:casetype/viewcase/:case_id',
+        path: 'case/:jur/:casetype/:case_id',
         resolve: {
             caseData: CaseResolve
         },

--- a/src/app/shared/components/table/table.component.html
+++ b/src/app/shared/components/table/table.component.html
@@ -3,7 +3,7 @@
         <ng-container cdkColumnDef="case_id">
             <cdk-header-cell *cdkHeaderCellDef class="govuk-table__header" attr.data-selector="case-number-header">Case number</cdk-header-cell>
             <cdk-cell class="govuk-table__cell" *cdkCellDef="let row;">
-                <a data-selector="case-reference-link" routerLink="/jurisdiction/{{row.case_jurisdiction}}/casetype/{{row.case_type_id}}/viewcase/{{row.case_id}}/summary">{{row.case_fields.case_ref}}</a>
+                <a data-selector="case-reference-link" routerLink="/case/{{row.case_jurisdiction}}/{{row.case_type_id}}/{{row.case_id}}/summary">{{row.case_fields.case_ref}}</a>
             </cdk-cell>
         </ng-container>
 

--- a/src/app/shared/components/table/table.component.spec.ts
+++ b/src/app/shared/components/table/table.component.spec.ts
@@ -224,13 +224,13 @@ describe('TableComponent', () => {
         it('should have a clickable case reference link to summary', () => {
             const links =
                 element.nativeElement.querySelectorAll(Selector.selector('table-component|case-reference-link'));
-            expect(links[0].attributes.href.value).toEqual('/jurisdiction/SSCS/casetype/Benefit/viewcase/1528476356357908/summary');
+            expect(links[0].attributes.href.value).toEqual('/case/SSCS/Benefit/1528476356357908/summary');
         });
 
         it('should have a clickable case status link', () => {
             const links =
                 element.nativeElement.querySelectorAll(Selector.selector('table-component|case-status-reference-link'));
-            expect(links[0].attributes.href.value).toEqual('/jurisdiction/SSCS/casetype/Benefit/viewcase/1528476356357908/casefile');
+            expect(links[0].attributes.href.value).toEqual('/case/SSCS/Benefit/1528476356357908/casefile');
         });
 
         it('should have ALL the headers', () => {

--- a/src/app/shared/pipes/case-status-goto/case.status.goto.spec.ts
+++ b/src/app/shared/pipes/case-status-goto/case.status.goto.spec.ts
@@ -15,7 +15,7 @@ fdescribe('CaseStatusGoto', () => {
         };
 
         const result = caseStatusGoToPipe.transform(status, jur, caseType, caseId);
-        expect(result).toBe('/jurisdiction/SSCS/casetype/Benefit/viewcase/3qweeq/questions');
+        expect(result).toBe('/case/SSCS/Benefit/3qweeq/questions');
     });
 
     it('should produce go to href with ID', () => {
@@ -26,6 +26,6 @@ fdescribe('CaseStatusGoto', () => {
         };
 
         const result = caseStatusGoToPipe.transform(status, jur, caseType, caseId);
-        expect(result).toBe('/jurisdiction/SSCS/casetype/Benefit/viewcase/3qweeq/questions/UUID');
+        expect(result).toBe('/case/SSCS/Benefit/3qweeq/questions/UUID');
     });
 });

--- a/src/app/shared/pipes/case-status-goto/case.status.goto.ts
+++ b/src/app/shared/pipes/case-status-goto/case.status.goto.ts
@@ -7,6 +7,6 @@ export class CaseStatusGoto implements PipeTransform {
 
     transform(status, jurisdiction, caseType, caseId) {
         const  href = status.ID ? `${status.actionGoTo}/${status.ID}` : status.actionGoTo;
-        return `/jurisdiction/${jurisdiction}/casetype/${caseType}/viewcase/${caseId}/${href}`;
+        return `/case/${jurisdiction}/${caseType}/${caseId}/${href}`;
     }
 }

--- a/test/e2e/features/app/summary.feature
+++ b/test/e2e/features/app/summary.feature
@@ -10,7 +10,40 @@ Feature: View Case Summary Page
 
     @RIUI_299 @all
     Scenario: I can see the summary page
-        Then I should expect the url to "match" "(.+)/viewcase/(.+)/summary"
+        Then I should expect the url to "match" "(.+)/(.+)/summary"
+
+
+
+    @all
+    Scenario: Verify summary page header, primary navigation link and case bar
+        Then I should see header logo text as Judicial case manager
+        Then I should see primary navigation link as Dashboard
+        Then I should see a jui case bar
+
+
+     @all
+     Scenario: Verify Summary page header link navigation
+         When I click on header logo Judicial case manager
+         Then I will be redirected to the JUI dashboard page
+         When I select a case type
+         Then I should see primary navigation link as Dashboard
+         When I click primary nav dashboard link
+         Then I will be redirected to the JUI dashboard page
+
+
+    @all
+    Scenario: Verify summary page sub nav links and their redirected pages
+        Then I should see Summary sub nav link
+        Then I can see sub nav links as Parties,Case file,Timeline
+        When I click on Parties sub nav link
+        Then I will be redirected to Parties page for that case
+        When I click on Case file sub nav link
+        Then I will be redirected to the Case file page for that case
+        When I click on Timeline sub nav link
+        Then I will be redirected to Timeline page for that case
+
+
+
 
 
 

--- a/test/e2e/features/pages/dashBoardPage.js
+++ b/test/e2e/features/pages/dashBoardPage.js
@@ -20,8 +20,8 @@ function dashBoardPage() {
     this.last_action_dates = element.all(by.css('[data-selector="lastModified-value"]'));
     this.sign_out_link = element(by.css('a.hmcts-header__navigation-link'));
     this.case_links = element.all(by.css('.cdk-column-case_id >a[href]'));
-    this.ng_links_FR_DIV = element.all(by.css('[ng-reflect-router-link="/jurisdiction/DIVORCE/casetype"][href]'));
-    this.ng_links_PIP = element.all(by.css('[ng-reflect-router-link="/jurisdiction/SSCS/casetype/Be"][href]'));
+    this.ng_links_FR_DIV = element.all(by.css('[ng-reflect-router-link="/case/DIVORCE/"][href]'));
+    this.ng_links_PIP = element.all(by.css('[ng-reflect-router-link="/case/SSCS/Be"][href]'));
     this.your_cases = element(by.css('span.govuk-heading-m'));
     this.table_column_header = element(by.css(".govuk-table__head.cdk-header-row[role='row']"));
     this.decision_needed_on_header = element(by.css(".govuk-table__header.cdk-header-cell.cdk-column-state"));

--- a/test/e2e/features/step_definitions/steps/dashBoard.steps.js
+++ b/test/e2e/features/step_definitions/steps/dashBoard.steps.js
@@ -46,7 +46,7 @@ defineSupportCode(function({ Given, When, Then }) {
                         .getAttribute('href')
                         .then(function(attr) {
                             console.log('test', attr);
-                            var re = new RegExp('(.+)/viewcase/(.+)/summary').compile();
+                            var re = new RegExp('(.+)/(.+)/summary').compile();
                             expect(attr)
                                 .to
                                 .match(re);

--- a/test/integration/tests/get_jui_case_summary.js
+++ b/test/integration/tests/get_jui_case_summary.js
@@ -9,7 +9,7 @@ suite('API/CASES -> FR case Summary Details', function()  {
                 response.statusCode.should.be.eql(200)
                 response.body.should.have.property('columns').which.is.Array();
                 var myVar = response.body.results[0].case_id;
-                url = '/api/cases/jurisdiction/DIVORCE/casetype/FinancialRemedyMVP2/' + myVar;
+                url = '/api/case/DIVORCE/FinancialRemedyMVP2/' + myVar;
                 console.log(url);
             });
     });


### PR DESCRIPTION
trying to unfiy our api can ui url so it easy to work with

in ccd ui they do `case/:judiristion/:casetype/:caseid`
in ccd-store api they do `/caseworkers/:userid/jurisdiction/:judiristion/casetype/:casetype/viewcase/:caseid` 
in jui ui we do `/jurisdiction/:judiristion/casetype/:casetype/viewcase/:caseid`
in jui api  we do `api/cases/jurisdiction/:judiristion/casetype/:casetype/:caseid`

i think its a good idea to try an make the url consistent so want to go with  
in jui ui we do `/case/:judiristion/:casetype/:caseid`
in jui api  we do `api/case/:judiristion/:casetype/:caseid`