### PR TITLE
[PREVIEW]: Refactor/footer component

### DIFF
--- a/src/app/domain/case-viewer/components/timeline-panel/timeline-panel.component.spec.ts
+++ b/src/app/domain/case-viewer/components/timeline-panel/timeline-panel.component.spec.ts
@@ -92,7 +92,6 @@ describe('TimelinePanelComponent', () => {
                     }
                 ]
             };
-
             fixture.whenStable().then(() => {
                 fixture.detectChanges();
             });

--- a/src/app/hmcts/components/hmcts-global-footer/hmcts-global-footer.component.html
+++ b/src/app/hmcts/components/hmcts-global-footer/hmcts-global-footer.component.html
@@ -1,13 +1,21 @@
 <footer class="hmcts-footer" role="contentinfo">
     <div class="hmcts-footer__container">
-        <h2 class="hmcts-footer__heading">{{help.heading}}</h2>
+        <h2 class="hmcts-footer__heading">
+            {{help.heading}}
+        </h2>
         <ul class="hmcts-footer__list">
-            <li class="hmcts-footer__list-item">Email: <a class="hmcts-footer__link" href="mailto:{{help.email.address}}">{{help.email.text}}</a></li>
-            <li class="hmcts-footer__list-item">Phone: {{help.phone.text}}</li>
-            <li class="hmcts-footer__list-item"><span class="visually-hidden">Opening times: </span>{{help.opening.text}}</li>
+            <li class="hmcts-footer__list-item">
+                Email: <a class="hmcts-footer__link" href="mailto:{{help.email.address}}">{{help.email.text}}</a>
+            </li>
+            <li class="hmcts-footer__list-item">
+                Phone: {{help.phone.text}}</li>
+            <li class="hmcts-footer__list-item">
+                <span class="visually-hidden">
+                 Opening times: </span>{{help.opening.text}}</li>
         </ul>
         <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-        <ul class="hmcts-footer__list hmcts-footer__list--inline">
+        <ul
+            class="hmcts-footer__list hmcts-footer__list--inline">
             <li class="hmcts-footer__list-item" *ngFor="let item of navigation.items">
                 <a class="hmcts-footer__link" href="{{item.href}}">{{item.text}}</a>
             </li>

--- a/src/app/hmcts/components/hmcts-global-footer/hmcts-global-footer.component.spec.ts
+++ b/src/app/hmcts/components/hmcts-global-footer/hmcts-global-footer.component.spec.ts
@@ -1,6 +1,7 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { HmctsGlobalFooterComponent } from './hmcts-global-footer.component';
+import {helpData, navigationData} from './mock/hmcts-global-footer.mock';
 
 describe('HmctsGlobalFooterComponent', () => {
   let component: HmctsGlobalFooterComponent;
@@ -16,6 +17,8 @@ describe('HmctsGlobalFooterComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(HmctsGlobalFooterComponent);
     component = fixture.componentInstance;
+    component.help = helpData;
+    component.navigation = navigationData;
     fixture.detectChanges();
   });
 

--- a/src/app/hmcts/components/hmcts-global-footer/hmcts-global-footer.component.ts
+++ b/src/app/hmcts/components/hmcts-global-footer/hmcts-global-footer.component.ts
@@ -1,4 +1,5 @@
 import {Component, Input, OnInit} from '@angular/core';
+import {Helper, Navigation} from '../../../shared/components/footer/footer.model';
 
 @Component({
     selector: 'app-hmcts-global-footer',
@@ -6,38 +7,10 @@ import {Component, Input, OnInit} from '@angular/core';
     styleUrls: ['./hmcts-global-footer.component.scss']
 })
 export class HmctsGlobalFooterComponent implements OnInit {
-
-    @Input() help = {
-        heading: 'Help',
-        email: {
-            address: '#',
-            text: 'service-desk@hmcts.gov.uk'
-        },
-        phone: {
-            text: '0207 633 4140'
-        },
-        opening: {
-            text: 'Monday to Friday, 8am to 6pm (excluding public holidays)'
-        }
-    };
-
-    @Input() navigation = {
-        items: [{
-            text: 'Terms and conditions',
-            href: '#'
-        }, {
-            text: 'Cookies',
-            href: '#'
-        }, {
-            text: 'Privacy policy',
-            href: '#'
-        }]
-    };
-
+    @Input() help: Helper;
+    @Input() navigation: Navigation;
 
     constructor() { }
-
-    ngOnInit() {
-    }
+    ngOnInit() {}
 
 }

--- a/src/app/hmcts/components/hmcts-global-footer/mock/hmcts-global-footer.mock.ts
+++ b/src/app/hmcts/components/hmcts-global-footer/mock/hmcts-global-footer.mock.ts
@@ -1,0 +1,23 @@
+import {Helper, Navigation} from '../../../../shared/components/footer/footer.model';
+import {environment} from '../../../../../environments/environment';
+
+export const helpData: Helper = {
+    heading: 'Help',
+    email: {
+        address: environment.serviceDeskEmail,
+        text: environment.serviceDeskEmail
+    },
+    phone: {
+        text: environment.serviceDeskTel
+    },
+    opening: {
+        text: 'Monday to Friday, 8am to 6pm (excluding public holidays)'
+    }
+};
+export const navigationData: Navigation = {
+    items: [
+        { text: 'Terms and conditions', href: 'terms-and-conditions'},
+        { text: 'Cookies', href: 'cookies' },
+        { text: 'Privacy policy', href: 'privacy-policy'}
+    ]
+};

--- a/src/app/routing/pages/hearings/hearing-confirmation/hearing-confirmation.component.spec.ts
+++ b/src/app/routing/pages/hearings/hearing-confirmation/hearing-confirmation.component.spec.ts
@@ -10,6 +10,7 @@ import {Observable} from 'rxjs';
 import {ActivatedRoute} from '@angular/router';
 import {GovukModule} from '../../../../govuk/govuk.module';
 import {HmctsModule} from '../../../../hmcts/hmcts.module';
+import {CUSTOM_ELEMENTS_SCHEMA} from '@angular/core';
 
 describe('HearingConfirmationComponent', () => {
     let component: HearingConfirmationComponent;
@@ -17,6 +18,7 @@ describe('HearingConfirmationComponent', () => {
 
     beforeEach(async(() => {
         TestBed.configureTestingModule({
+            schemas: [CUSTOM_ELEMENTS_SCHEMA],
             declarations: [
                 HearingConfirmationComponent
             ],

--- a/src/app/routing/pages/hearings/root/root.component.spec.ts
+++ b/src/app/routing/pages/hearings/root/root.component.spec.ts
@@ -8,6 +8,7 @@ import {Observable} from 'rxjs';
 import {ActivatedRoute} from '@angular/router';
 import {GovukModule} from '../../../../govuk/govuk.module';
 import {HmctsModule} from '../../../../hmcts/hmcts.module';
+import {CUSTOM_ELEMENTS_SCHEMA} from '@angular/core';
 
 describe('HearingRootComponent', () => {
     let component: HearingRootComponent;
@@ -18,6 +19,7 @@ describe('HearingRootComponent', () => {
             declarations: [
                 HearingRootComponent
             ],
+            schemas: [CUSTOM_ELEMENTS_SCHEMA],
             imports: [
                 DomainModule,
                 SharedModule,

--- a/src/app/shared/components/footer/footer.component.html
+++ b/src/app/shared/components/footer/footer.component.html
@@ -1,14 +1,4 @@
 <app-hmcts-global-footer
-    [help]="{
-    heading: 'Help',
-    email: { address: email, text: email },
-    phone: { text: phone },
-    opening: { text: 'Monday to Friday, 8am to 6pm (excluding public holidays)' }
-    }"
-
-    [navigation]="{ items: [
-    { text: 'Terms and conditions',href: 'terms-and-conditions'},
-    { text: 'Cookies', href: 'cookies' },
-    { text: 'Privacy policy', href: 'privacy-policy'}
-    ]}"
+    [help]="helpData"
+    [navigation]="navigationData"
 ></app-hmcts-global-footer>

--- a/src/app/shared/components/footer/footer.component.spec.ts
+++ b/src/app/shared/components/footer/footer.component.spec.ts
@@ -1,6 +1,7 @@
 import {async, ComponentFixture, TestBed} from '@angular/core/testing';
 
 import {FooterComponent} from './footer.component';
+import {CUSTOM_ELEMENTS_SCHEMA} from '@angular/core';
 
 describe('FooterComponent', () => {
     let component: FooterComponent;
@@ -8,6 +9,7 @@ describe('FooterComponent', () => {
 
     beforeEach(async(() => {
         TestBed.configureTestingModule({
+            schemas: [CUSTOM_ELEMENTS_SCHEMA],
             declarations: [FooterComponent]
         })
             .compileComponents();

--- a/src/app/shared/components/footer/footer.component.ts
+++ b/src/app/shared/components/footer/footer.component.ts
@@ -1,13 +1,30 @@
-import {Component} from '@angular/core';
-
+import { Component } from '@angular/core';
+import { Helper, Navigation } from './footer.model';
+import { environment } from '../../../../environments/environment';
 @Component({
     selector: 'app-footer',
     templateUrl: './footer.component.html',
     styleUrls: ['./footer.component.scss']
 })
 export class FooterComponent {
-
-    email = 'service-desk@hmcts.gov.uk';
-    phone = '';
-
+    public helpData: Helper = {
+        heading: 'Help',
+        email: {
+            address: environment.serviceDeskEmail,
+            text: environment.serviceDeskEmail
+        },
+        phone: {
+            text: environment.serviceDeskTel
+        },
+        opening: {
+            text: 'Monday to Friday, 8am to 6pm (excluding public holidays)'
+        }
+    };
+    public navigationData: Navigation = {
+        items: [
+            { text: 'Terms and conditions', href: 'terms-and-conditions'},
+            { text: 'Cookies', href: 'cookies' },
+            { text: 'Privacy policy', href: 'privacy-policy'}
+        ]
+    };
 }

--- a/src/app/shared/components/footer/footer.model.ts
+++ b/src/app/shared/components/footer/footer.model.ts
@@ -4,10 +4,9 @@ export interface Helper {
     phone: { text: string; };
     opening: { text: string; };
 }
+export interface NavigationItems {
+    text: string; href: string;
+}
 export interface Navigation {
-    items: [
-        { text: string; href: string;},
-        { text: string; href: string; },
-        { text: string; href: string;}
-   ];
+    items: Array<NavigationItems>;
 }

--- a/src/app/shared/components/footer/footer.model.ts
+++ b/src/app/shared/components/footer/footer.model.ts
@@ -1,0 +1,13 @@
+export interface Helper {
+    heading: string;
+    email: { address: string; text: string; };
+    phone: { text: string; };
+    opening: { text: string; };
+}
+export interface Navigation {
+    items: [
+        { text: string; href: string;},
+        { text: string; href: string; },
+        { text: string; href: string;}
+   ];
+}

--- a/src/app/shared/components/table/mock/table.mock.ts
+++ b/src/app/shared/components/table/mock/table.mock.ts
@@ -1,0 +1,155 @@
+export interface JuiCaseField {
+    id: string;
+    type: string;
+    min: null;
+    max: null;
+    regular_expression: null;
+    fixed_list_items: Array<any>;
+    complex_fields: Array<any>;
+    collection_field_type: null;
+}
+
+export interface JuiColumn {
+    label: string;
+    order: number;
+    case_field_id: string;
+    case_field_type: JuiCaseField;
+}
+
+export const mockColumData: Array<JuiColumn> = [
+    {
+        'label': 'Ignore this column',
+        'order': 2,
+        'case_field_id': 'ignoreignore',
+        'case_field_type': {
+            'id': 'Text',
+            'type': 'Text',
+            'min': null,
+            'max': null,
+            'regular_expression': null,
+            'fixed_list_items': [],
+            'complex_fields': [],
+            'collection_field_type': null
+        }
+    },
+    {
+        'label': 'Parties',
+        'order': 2,
+        'case_field_id': 'parties',
+        'case_field_type': {
+            'id': 'Text',
+            'type': 'Text',
+            'min': null,
+            'max': null,
+            'regular_expression': null,
+            'fixed_list_items': [],
+            'complex_fields': [],
+            'collection_field_type': null
+        }
+    },
+    {
+        'label': 'Type',
+        'order': 3,
+        'case_field_id': 'type',
+        'case_field_type': {
+            'id': 'Text',
+            'type': 'Text',
+            'min': null,
+            'max': null,
+            'regular_expression': null,
+            'fixed_list_items': [],
+            'complex_fields': [],
+            'collection_field_type': null
+        }
+    },
+    {
+        'label': 'Status',
+        'order': 4,
+        'case_field_id': 'status',
+        'case_field_type': {
+            'id': 'Text',
+            'type': 'Text',
+            'min': null,
+            'max': null,
+            'regular_expression': null,
+            'fixed_list_items': [],
+            'complex_fields': [],
+            'collection_field_type': null
+        }
+    },
+    {
+        'label': 'Date',
+        'order': 5,
+        'case_field_id': 'caseCreated',
+        'case_field_type': {
+            'id': 'Date',
+            'type': 'Date',
+            'min': null,
+            'max': null,
+            'regular_expression': null,
+            'fixed_list_items': [],
+            'complex_fields': [],
+            'collection_field_type': null
+        }
+    },
+    {
+        'label': 'Last Action',
+        'order': 7,
+        'case_field_id': 'caseLastActioned',
+        'case_field_type': {
+            'id': 'Date',
+            'type': 'Date',
+            'min': null,
+            'max': null,
+            'regular_expression': null,
+            'fixed_list_items': [],
+            'complex_fields': [],
+            'collection_field_type': null
+        }
+    }
+];
+export const mockResultData = {
+    'case_id': 1528476356357908,
+    'case_reference': '123-123-123',
+    'case_jurisdiction': 'SSCS',
+    'case_type_id':'Benefit',
+    'case_fields': {
+        'caseRef': null,
+        'parties': 'A v May_146863',
+        'type': 'SSCS',
+        'status': {
+            'name': 'Draft Consent Order',
+            'action_goto': 'casefile'
+        },
+        'caseCreated': '2018-06-08T16:45:56.301',
+        'caseLastActioned': '2018-06-11T10:36:58.652'
+    }
+};
+export const mockResultData2 = {
+    'case_id': 1528476358303157,
+    'case_reference': '321-321-321',
+    'case_jurisdiction': 'SSCS',
+    'case_type_id':'Benefit',
+    'case_fields': {
+        'caseRef': null,
+        'parties': 'B v May_417228',
+        'type': 'SSCS',
+        'status': {
+            'name': 'Draft Consent Order',
+            'action_goto': 'casefile'
+        },
+        'caseCreated': '2018-06-08T16:45:58.349',
+        'caseLastActioned': '2018-06-08T16:45:58.349'
+    }
+};
+export const mockDataWithTwoRows = {
+    'columns': mockColumData,
+    'results': [
+        mockResultData,
+        mockResultData2
+    ]
+};
+export const mockDataWithNoRows = {
+    'columns': mockColumData,
+    'results': []
+};

--- a/src/app/shared/components/table/table.component.spec.ts
+++ b/src/app/shared/components/table/table.component.spec.ts
@@ -6,6 +6,7 @@ import {DebugElement} from '@angular/core';
 
 import {Selector} from '../../../../../test/selector-helper';
 import {RouterTestingModule} from '@angular/router/testing';
+import {mockColumData, mockDataWithNoRows, mockDataWithTwoRows, mockResultData, mockResultData2} from './mock/table.mock';
 
 let columns;
 let result1;
@@ -19,145 +20,12 @@ describe('TableComponent', () => {
     let element: DebugElement;
 
     beforeEach(() => {
-        columns = [
-            {
-                'label': 'Ignore this column',
-                'order': 2,
-                'case_field_id': 'ignoreignore',
-                'case_field_type': {
-                    'id': 'Text',
-                    'type': 'Text',
-                    'min': null,
-                    'max': null,
-                    'regular_expression': null,
-                    'fixed_list_items': [],
-                    'complex_fields': [],
-                    'collection_field_type': null
-                }
-            },
-            {
-                'label': 'Parties',
-                'order': 2,
-                'case_field_id': 'parties',
-                'case_field_type': {
-                    'id': 'Text',
-                    'type': 'Text',
-                    'min': null,
-                    'max': null,
-                    'regular_expression': null,
-                    'fixed_list_items': [],
-                    'complex_fields': [],
-                    'collection_field_type': null
-                }
-            },
-            {
-                'label': 'Type',
-                'order': 3,
-                'case_field_id': 'type',
-                'case_field_type': {
-                    'id': 'Text',
-                    'type': 'Text',
-                    'min': null,
-                    'max': null,
-                    'regular_expression': null,
-                    'fixed_list_items': [],
-                    'complex_fields': [],
-                    'collection_field_type': null
-                }
-            },
-            {
-                'label': 'Status',
-                'order': 4,
-                'case_field_id': 'status',
-                'case_field_type': {
-                    'id': 'Text',
-                    'type': 'Text',
-                    'min': null,
-                    'max': null,
-                    'regular_expression': null,
-                    'fixed_list_items': [],
-                    'complex_fields': [],
-                    'collection_field_type': null
-                }
-            },
-            {
-                'label': 'Date',
-                'order': 5,
-                'case_field_id': 'caseCreated',
-                'case_field_type': {
-                    'id': 'Date',
-                    'type': 'Date',
-                    'min': null,
-                    'max': null,
-                    'regular_expression': null,
-                    'fixed_list_items': [],
-                    'complex_fields': [],
-                    'collection_field_type': null
-                }
-            },
-            {
-                'label': 'Last Action',
-                'order': 7,
-                'case_field_id': 'caseLastActioned',
-                'case_field_type': {
-                    'id': 'Date',
-                    'type': 'Date',
-                    'min': null,
-                    'max': null,
-                    'regular_expression': null,
-                    'fixed_list_items': [],
-                    'complex_fields': [],
-                    'collection_field_type': null
-                }
-            }
-        ];
+        columns = mockColumData;
+        result1 = mockResultData;
+        result2 = mockResultData2;
 
-        result1 = {
-            'case_id': 1528476356357908,
-            'case_reference': '123-123-123',
-            'case_jurisdiction': 'SSCS',
-            'case_type_id':'Benefit',
-            'case_fields': {
-                'caseRef': null,
-                'parties': 'A v May_146863',
-                'type': 'SSCS',
-                'status': {
-                    'name': 'Draft Consent Order',
-                    'action_goto': 'casefile'
-                },
-                'caseCreated': '2018-06-08T16:45:56.301',
-                'caseLastActioned': '2018-06-11T10:36:58.652'
-            }
-        };
-        result2 = {
-            'case_id': 1528476358303157,
-            'case_reference': '321-321-321',
-            'case_jurisdiction': 'SSCS',
-            'case_type_id':'Benefit',
-            'case_fields': {
-                'caseRef': null,
-                'parties': 'B v May_417228',
-                'type': 'SSCS',
-                'status': {
-                    'name': 'Draft Consent Order',
-                    'action_goto': 'casefile'
-                },
-                'caseCreated': '2018-06-08T16:45:58.349',
-                'caseLastActioned': '2018-06-08T16:45:58.349'
-            }
-        };
-
-        dataWithTwoRows = {
-            'columns': columns,
-            'results': [
-                result1,
-                result2
-            ]
-        };
-        dataWithNoRows = {
-            'columns': columns,
-            'results': []
-        };
+        dataWithTwoRows = mockDataWithTwoRows;
+        dataWithNoRows = mockDataWithNoRows;
     });
 
 

--- a/src/app/shared/components/timeline/mock/timeline.mock.ts
+++ b/src/app/shared/components/timeline/mock/timeline.mock.ts
@@ -1,0 +1,18 @@
+export const mockData = [
+    {
+        title: 'HEARING',
+        by: 'John Smith',
+        dateUtc: '2018-08-06T15:14:11Z',
+        date: '6 Aug 2018',
+        time: '15:14pm',
+        documents: []
+    },
+    {
+        title: 'CREATED_EVENT',
+        by: 'Gilbert Smith',
+        dateUtc: '2018-08-06T15:14:11Z',
+        date: '6 Aug 2018',
+        time: '15:14pm',
+        documents: []
+    }
+];

--- a/src/app/shared/components/timeline/timeline.component.spec.ts
+++ b/src/app/shared/components/timeline/timeline.component.spec.ts
@@ -1,3 +1,4 @@
+///<reference path="mock/timeline.mock.ts"/>
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { CaseViewerModule } from '../../../domain/case-viewer/case-viewer.module';
 import { DebugElement } from '@angular/core';
@@ -5,6 +6,7 @@ import { Selector } from '../../../../../test/selector-helper';
 import {TimelineComponent} from './timeline.component';
 import {HmctsTimelineComponent} from '../../../hmcts/components/hmcts-timeline/hmcts-timeline.component';
 import {SentenceCasePipe} from '../../../hmcts/pipes/sentence-case/sentence-case-pipe';
+import { mockData } from './mock/timeline.mock';
 
 describe('TimelineComponent', () => {
     let component: TimelineComponent;
@@ -31,24 +33,7 @@ describe('TimelineComponent', () => {
 
     describe('when some data is available', () => {
         beforeEach(async(() => {
-            component.events = [
-                {
-                    title: 'HEARING',
-                    by: 'John Smith',
-                    dateUtc: '2018-08-06T15:14:11Z',
-                    date: '6 Aug 2018',
-                    time: '15:14pm',
-                    documents: []
-                },
-                {
-                    title: 'CREATED_EVENT',
-                    by: 'Gilbert Smith',
-                    dateUtc: '2018-08-06T15:14:11Z',
-                    date: '6 Aug 2018',
-                    time: '15:14pm',
-                    documents: []
-                }
-            ];
+            component.events = mockData;
 
             fixture.whenStable().then(() => {
                 fixture.detectChanges();

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,4 +1,6 @@
 export const environment = {
     production: true,
-    googleAnalyticsKey: 'UA-124734893-1'
+    googleAnalyticsKey: 'UA-124734893-1',
+    serviceDeskEmail: 'service-desk@hmcts.gov.uk',
+    serviceDeskTel: '0207 633 4140'
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -6,5 +6,7 @@
 export const environment = {
     production: false,
     // remove this line if GA is need only for production. For time being, to test on aat env, added this.
-    googleAnalyticsKey: 'UA-124734893-1'
+    googleAnalyticsKey: 'UA-124734893-1',
+    serviceDeskEmail: 'service-desk@hmcts.gov.uk',
+    serviceDeskTel: '0207 633 4140'
 };


### PR DESCRIPTION
Cleaned up the Input data cycle in HmctsGlobalFooterComponent, it was overwritten by local data. 
Created interfaces
Moved global business data to environment file as for example tel and email
Fixed Spec test to test the Input data in the HmctsGlobalFooterComponent component
Created a separate mock data file : `hmcts-global-footer.mock.ts`
