### PR TITLE
disable sscs tests as judge details wiped off

### DIFF
--- a/test/e2e/features/app/dashBoard.feature
+++ b/test/e2e/features/app/dashBoard.feature
@@ -12,7 +12,7 @@ Feature: Dashboard
         Then I should see table each column header text as Case number, Parties, Type, Decision needed on, Case received, Date of last event
 
 
-    @RIUI_370 @RIUI_418 @all
+    @RIUI_370 @RIUI_418
     Scenario Outline: Verify available case types on Jui Dashboard
         When I am logged into JUI web app with FR judge details
         Then I will be redirected to the JUI dashboard page

--- a/test/e2e/features/app/login.feature
+++ b/test/e2e/features/app/login.feature
@@ -19,7 +19,7 @@ Feature: Login
         Then I should be redirected to JUI dashboard page
 
 
-    @RIUI_289 @logout @all @smoke
+    @RIUI_289 @logout
     Scenario: log out from JUI
         Given I am logged into JUI web app with SSCS judge details
         Then I should be redirected to JUI dashboard page


### PR DESCRIPTION


### JIRA link (if applicable) ###



### Change description ###

SSCS judge users are wiped off so cant login and logout for few scenarios, disabling tests until sscs judge login works

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
