### PR TITLE
Remove typo when saving the changes

### DIFF
--- a/src/public/javascripts/pdf.worker.js
+++ b/src/public/javascripts/pdf.worker.js
@@ -2300,7 +2300,6 @@ function warn(msg) {
 
 // Deprecated API function -- display regardless of the PDFJS.verbosity setting.
 function deprecated(details) {
-  s
 }
 
 // Fatal errors that should trigger the fallback UI and halt execution by


### PR DESCRIPTION
This is a fix-up to 1b116739e6af893df392117d0dcf7f4e7b8c7ef2.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
[x] Hopefully not
```
