### PR TITLE
Removing visual error messages, error stack is still logged out to th…

### DIFF
--- a/src/app/domain/components/search-result/search-result.component.html
+++ b/src/app/domain/components/search-result/search-result.component.html
@@ -16,18 +16,6 @@
         <!-- Error -->
         <div *ngSwitchCase="CASES_LOAD_ERROR">
             <div data-selector="error-text" class="govuk-error-message">There was an error getting your cases.</div>
-
-            <div class="error-message">
-                <div>Error: {{errorStackResponse.error}}</div>
-                <div>Status code: {{errorStackResponse.status}}</div>
-                <div>Message: {{errorStackResponse.message}}</div>
-                <div>On path: {{errorStackResponse.path}}</div>
-                <div>Time: {{errorStackResponse.timestamp}}</div>
-                <div>Stack trace:</div>
-                <div *ngFor="let error of minimalErrorStack | keyvalue">
-                    {{error.key}} : {{error.value}}
-                </div>
-            </div>
         </div>
     </div>
 </div>

--- a/src/app/domain/components/search-result/search-result.component.ts
+++ b/src/app/domain/components/search-result/search-result.component.ts
@@ -58,6 +58,9 @@ export class SearchResultComponent implements OnInit {
 
         console.log('HttpErrorResponse Error:');
         console.log(errorStack);
+
+        console.log('Minimal Error Stack:');
+        console.log(this.minimalErrorStack);
     }
 
     /**


### PR DESCRIPTION
…e console.

As discussed with Vamshi. The error being logged out to the view, is confusing to a user. It is still seen within the console, for developers.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
