### PR TITLE
fix: fixed issue where the service could return no cases and error no…

### DIFF
--- a/api/controllers/case-list/index.spec.ts
+++ b/api/controllers/case-list/index.spec.ts
@@ -13,26 +13,7 @@ import * as cohCorApi from '../../services/cohQA'
 import * as idamApi from '../../services/idam'
 import * as getAllQuestionsByCase from '../questions/index'
 import * as assignCase from './assignCase'
-import {
-    aggregatedData,
-    appendCOR,
-    appendQuestionsRound,
-    assign,
-    combineLists,
-    getCases,
-    getCOR,
-    getHearingWithQuestionData,
-    getMutiJudCaseAssignedCases,
-    getMutiJudCaseRaw,
-    getMutiJudCaseRawCoh,
-    getQuestionData,
-    raw,
-    rawCOH,
-    sortCases,
-    sortTransformedCases,
-    unassign,
-    unassignAll,
-} from './index'
+import * as caseList from './index'
 
 chai.use(sinonChai)
 describe('index', () => {
@@ -50,7 +31,7 @@ describe('index', () => {
             const userDetails = { id: 1, name: 'John Doe', roles: [1, 2, 3] }
             const stub = sinon.stub(ccdStore, 'getMutiJudCCDCases')
             stub.returns([1, 2, 3])
-            const result = await getMutiJudCaseRaw(userDetails)
+            const result = await caseList.getMutiJudCaseRaw(userDetails)
             expect(stub).to.be.called
             expect(result).to.be.an('array')
             stub.restore()
@@ -59,7 +40,7 @@ describe('index', () => {
     describe('combineLists', () => {
         it('Should return concatenated array', () => {
             const lists = [[1, 2], [3, 4]]
-            const result = combineLists(lists)
+            const result = caseList.combineLists(lists)
             expect(result).to.be.an('array')
             expect(result).to.eql([1, 2, 3, 4])
         })
@@ -71,7 +52,7 @@ describe('index', () => {
                 { id: 2, case_fields: { lastModified: 1549899156 } },
                 { id: 3, case_fields: { lastModified: 1549899216 } },
             ]
-            const result = sortTransformedCases(results)
+            const result = caseList.sortTransformedCases(results)
             expect(result).to.be.an('array')
             expect(result[0].id).to.equal(2)
             expect(result[1].id).to.equal(3)
@@ -85,7 +66,7 @@ describe('index', () => {
                 { id: 2, last_modified: 1549899156 },
                 { id: 3, last_modified: 1549899216 },
             ]
-            const result = sortCases(results)
+            const result = caseList.sortCases(results)
             expect(result).to.be.an('array')
             expect(result[0].id).to.equal(2)
             expect(result[1].id).to.equal(3)
@@ -95,7 +76,7 @@ describe('index', () => {
     describe('aggregatedData', () => {
         it('Should return object', () => {
             const results = [{ id: 1 }, { id: 2 }, { id: 3 }]
-            const result = aggregatedData(results)
+            const result = caseList.aggregatedData(results)
             expect(result).to.be.an('object')
             expect(result.columns).to.not.be.null
             expect(result.results).to.equal(results)
@@ -117,7 +98,7 @@ describe('index', () => {
             const stub = sinon.stub(cohCorApi, 'getHearingByCase')
             stub.returns(stubReturns)
             const res = mockRes()
-            const result = await appendCOR(res, caseLists)
+            const result = await caseList.appendCOR(res, caseLists)
             expect(result).to.be.an('array')
             expect(result[0]).to.be.an('array')
             stub.restore()
@@ -131,7 +112,7 @@ describe('index', () => {
             const stub = sinon.stub(cohCorApi, 'getHearingByCase')
             stub.returns(Promise.resolve(123))
             const res = mockRes()
-            const result = await getCOR(res, casesData)
+            const result = await caseList.getCOR(res, casesData)
             expect(stub).to.be.calledWith('1&case_id=2&case_id=3')
             stub.restore()
         })
@@ -154,7 +135,7 @@ describe('index', () => {
             const stub2 = sinon.stub(coh, 'getDecision')
             stub.returns(Promise.resolve(stubReturns))
             const res = mockRes()
-            const result = await getCOR(res, casesData)
+            const result = await caseList.getCOR(res, casesData)
             expect(result).to.be.an('array')
             expect(result[0].id).to.eql(1)
 
@@ -183,7 +164,7 @@ describe('index', () => {
             stub2.returns({})
             const res = mockRes()
 
-            const result = await getCOR(res, casesData)
+            const result = await caseList.getCOR(res, casesData)
             expect(stub2).to.be.calledWith('2a')
             stub.restore()
             stub2.restore()
@@ -198,7 +179,7 @@ describe('index', () => {
             const userId = 2
             const stub = sinon.stub(getAllQuestionsByCase, 'getAllQuestionsByCase')
             stub.returns({ questions: 2 })
-            const result = await getHearingWithQuestionData(caseData, userId)
+            const result = await caseList.getHearingWithQuestionData(caseData, userId)
             expect(result).to.be.an('object')
             expect(result).to.eql(expectedResult)
             stub.restore()
@@ -212,7 +193,7 @@ describe('index', () => {
                 },
             ]
             const userId = 2
-            const result = await getQuestionData(caseLists, userId)
+            const result = await caseList.getQuestionData(caseLists, userId)
             expect(result).to.be.an('array')
         })
         it("Should return 'getHearingWithQuestionData' if 'hearing_data'", async () => {
@@ -225,7 +206,7 @@ describe('index', () => {
             const expectedResult = [{ id: 1, questions: { questions: 2 } }]
             const userId = 2
             const stub = sinon.stub(getAllQuestionsByCase, 'getAllQuestionsByCase').resolves({ questions: 2 })
-            await getQuestionData(caseLists, userId).then(result => {
+            await caseList.getQuestionData(caseLists, userId).then(result => {
                 expect(result).to.be.an('array')
                 expect(result).to.eql(expectedResult)
             })
@@ -237,7 +218,7 @@ describe('index', () => {
             const userDetails = { id: 1, roles: [1, 2, 3] }
             const stub = sinon.stub(ccdStore, 'getMutiJudCCDCases')
             stub.resolves(123)
-            const result = await getMutiJudCaseAssignedCases(userDetails)
+            const result = await caseList.getMutiJudCaseAssignedCases(userDetails)
             expect(stub).to.be.called
             expect(result).to.equal(123)
             stub.restore()
@@ -253,12 +234,12 @@ describe('index', () => {
                 },
             }
             const stub = sinon.stub(idamApi, 'getUser')
-            const stub2 = sinon.stub(filters, 'filterByCaseTypeAndRole')
+            const stub2 = sinon.stub(caseList, 'getMutiJudCaseTransformed')
             const stub3 = sinon.stub(utils, 'asyncReturnOrError')
             stub.resolves({ id: 1, roles: [1, 2, 3] })
             stub2.resolves([1, 2, 3])
             stub3.resolves({results: [1, 2, 3]})
-            const result = await getCases(res)
+            const result = await caseList.getCases(res)
             expect(stub).to.be.called
             // expect(result).to.be.an('array')
             stub.restore()
@@ -281,7 +262,7 @@ describe('index', () => {
             stub.resolves({ id: 1, roles: [1, 2, 3] })
             stub2.resolves([1, 2, 3])
             stub3.resolves([1, 2, 3])
-            const result = await unassign(res)
+            const result = await caseList.unassign(res)
             expect(stub).to.be.called
             // expect(result).to.be.an('array')
             stub.restore()
@@ -309,7 +290,7 @@ describe('index', () => {
             stub.returns({ id: 1, roles: [1, 2, 3] })
             stub2.resolves([1, 2, 3])
             stub3.resolves([1, 2, 3])
-            const result = await assign(req, res)
+            const result = await caseList.assign(req, res)
             expect(stub).to.be.called
             // expect(result).to.be.an('array')
             stub.restore()
@@ -332,7 +313,7 @@ describe('index', () => {
             stub.returns({ id: 1, roles: [1, 2, 3] })
             stub2.resolves([1, 2, 3])
             stub3.resolves([1, 2, 3])
-            const result = await raw(res)
+            const result = await caseList.raw(res)
             expect(stub).to.be.called
             // expect(result).to.be.an('array')
             stub.restore()
@@ -360,7 +341,7 @@ describe('index', () => {
                 { id: 2, last_modified: 1549899156 },
                 { id: 3, last_modified: 1549899216 },
             ])
-            const result = await rawCOH(res)
+            const result = await caseList.rawCOH(res)
             expect(stub).to.be.called
             // expect(result).to.be.an('array')
             stub.restore()
@@ -383,7 +364,7 @@ describe('index', () => {
             stub.returns(1)
             stub2.resolves({ id: 2 })
             stub3.resolves(3)
-            const result = await unassignAll(req, res)
+            const result = await caseList.unassignAll(req, res)
             expect(stub).to.be.called
             expect(result).to.equal(1)
             stub.restore()
@@ -397,7 +378,7 @@ describe('index', () => {
             const userId = 1
             const stub = sinon.stub(getAllQuestionsByCase, 'getAllQuestionsByCase')
             stub.resolves(123)
-            const result = await appendQuestionsRound(caseLists, userId)
+            const result = await caseList.appendQuestionsRound(caseLists, userId)
             expect(stub).to.not.be.called
             expect(result).to.eql([[], []])
             stub.restore()
@@ -408,7 +389,7 @@ describe('index', () => {
                 [{ id: 3, question_data: 3 }, { id: 4, question_data: 4 }],
             ]
             const userId = 1
-            const result = await appendQuestionsRound(caseLists, userId)
+            const result = await caseList.appendQuestionsRound(caseLists, userId)
             expect(result).to.be.an('array')
             expect(result[1]).to.not.be.null
         })

--- a/api/controllers/case-list/index.ts
+++ b/api/controllers/case-list/index.ts
@@ -21,6 +21,7 @@ const getListTemplate = require('./templates/index')
 const { caseStateFilter } = require('../../lib/processors/case-state-util')
 import { ERROR_UNABLE_TO_APPEND_TO_COR, ERROR_UNABLE_TO_APPEND_QRS, ERROR_UNABLE_TO_GET_CASES, ERROR_UNABLE_TO_GET_HEARING_BY_CASE } from '../../lib/errors'
 const logger = log4jui.getLogger('case-list')
+const that = this
 
 export async function getCOR(res, casesData) {
     const caseIds = casesData.map(caseRow => `${caseRow.id}`).join('&case_id=')
@@ -235,6 +236,11 @@ export async function getMutiJudCaseTransformed(res, userDetails) {
     caseList = await asyncReturnOrError(getMutiJudCCDCases(userDetails.id, jurisdictions), 'Error getting Multi' +
         'Jurisdictional assigned cases.', null, logger, false)
 
+    if (!isAnyCaseViewableByAJudge(caseList)) {
+
+        return { message: JUDGE_HAS_NO_VIEWABLE_CASES }
+    }
+
     caseList = await asyncReturnOrError(appendCOR(res, caseList), ERROR_UNABLE_TO_APPEND_TO_COR.humanStatusCode,
         null, logger, false)
 
@@ -308,7 +314,7 @@ export async function getCases(res) {
 
     while (tryCCD < config.maxCCDRetries && !results) {
         // need to disable error sending here and catch it later if retrying
-        results = await asyncReturnOrError(getMutiJudCaseTransformed(res, user), ' Error getting case list',
+        results = await asyncReturnOrError(that.getMutiJudCaseTransformed(res, user), ' Error getting case list',
             res, logger, false)
 
         tryCCD++

--- a/src/app/routing/pages/decisions/decision-confirmation/decision-confirmation.component.spec.ts
+++ b/src/app/routing/pages/decisions/decision-confirmation/decision-confirmation.component.spec.ts
@@ -106,7 +106,7 @@ describe('DecisionConfirmationComponent', () => {
             'preliminary-advanced': true
         }
         component.setPageData(visitedPages);
-        expect(JSON.stringify(component.display)).toBe(JSON.stringify({header: "Tribunal's view submitted", text: "The tribunal's view will be sent to the appelant and DWP."}));
+        expect(JSON.stringify(component.display)).toBe(JSON.stringify({header: "Tribunal's view submitted", text: "The tribunal's view will be sent to the appellant and DWP."}));
     });
 
     it('should set "final decision" page data if "final decision" page visited', () => {
@@ -114,6 +114,6 @@ describe('DecisionConfirmationComponent', () => {
             'final-decision': true
         }
         component.setPageData(visitedPages);
-        expect(JSON.stringify(component.display)).toBe(JSON.stringify({header: "Tribunal's decision submitted", text: "The tribunal's decision will be sent to the appelant and DWP."}));
+        expect(JSON.stringify(component.display)).toBe(JSON.stringify({header: "Tribunal's decision submitted", text: "The tribunal's decision will be sent to the appellant and DWP."}));
     });
 });

--- a/src/app/routing/pages/decisions/decision-confirmation/decision-confirmation.component.ts
+++ b/src/app/routing/pages/decisions/decision-confirmation/decision-confirmation.component.ts
@@ -21,11 +21,11 @@ export class DecisionConfirmationComponent implements OnInit {
     pages: pages = {
         tribunal: {
             header:'Tribunal\'s view submitted',
-            text: 'The tribunal\'s view will be sent to the appelant and DWP.'
+            text: 'The tribunal\'s view will be sent to the appellant and DWP.'
         },
         finaldesision: {
             header:'Tribunal\'s decision submitted',
-            text: 'The tribunal\'s decision will be sent to the appelant and DWP.'
+            text: 'The tribunal\'s decision will be sent to the appellant and DWP.'
         }
     };
 

--- a/test/e2e/config/conf.js
+++ b/test/e2e/config/conf.js
@@ -92,7 +92,7 @@ const config = {
         strict: true,
         // format: ['node_modules/cucumber-pretty'],
         format: ['node_modules/cucumber-pretty', 'json:reports_json/results.json'],
-        tags: ['@ignore'],
+        tags: ['@all'],
         require: [
             '../support/timeout.js',
             '../support/world.js',

--- a/test/e2e/config/crossbrowser.conf.js
+++ b/test/e2e/config/crossbrowser.conf.js
@@ -11,7 +11,7 @@ const config = {
     framework: 'custom',
     frameworkPath: require.resolve('protractor-cucumber-framework'),
 
-    sauceSeleniumAddress: 'ondemand.saucelabs.com:443/wd/hub',
+    sauceSeleniumAddress: 'ondemand.eu-central-1.com:443/wd/hub',
     allScriptsTimeout: 111000,
     specs: ['../features/**/*.feature'],
 

--- a/test/e2e/config/smoke.conf.js
+++ b/test/e2e/config/smoke.conf.js
@@ -96,7 +96,7 @@ const config = {
         strict: true,
         // format: ['node_modules/cucumber-pretty'],
         format: ['node_modules/cucumber-pretty', 'json:reports_json/results.json'],
-        tags: ['@ignore'],
+        tags: ['@all'],
         require: [
             '../support/timeout.js',
             '../support/world.js',


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RIUI-1667


### Change description ###
Ensured we capture the edge case when service returns no cases assigned for logged in user, bubble the error back up.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
