### PR TITLE
updated redis-cache module source in terraform

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -54,7 +54,7 @@ module "app" {
 }
 
 module "redis-cache" {
-    source      = "git@github.com:contino/moj-module-redis?ref=master"
+    source      = "git@github.com:hmcts/cnp-module-redis?ref=master"
     product     = "${var.product}-redis"
     location    = "${var.location}"
     env         = "${var.env}"


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/EUI-744


### Change description ###
updated terraform file to remove deprecation warnings.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
